### PR TITLE
Fixed history_6rolls_35bag.lua for real.

### DIFF
--- a/tetris/randomizers/history_6rolls_35bag.lua
+++ b/tetris/randomizers/history_6rolls_35bag.lua
@@ -35,14 +35,14 @@ function History6Rolls35PoolRandomizer:initialize()
 end
 
 function History6Rolls35PoolRandomizer:generatePiece()
-	local index, x, highscore, didreroll, didfirst
-	didreroll = false -- did we reroll
-	didfirst = false -- did we just do the first piece
+	local index, x, highscore, did_reroll, did_first
+	did_reroll = false -- did we reroll
+	did_first = false -- did we just do the first piece
 	if self.first then
 		index = love.math.random(20) -- hack to pick non S Z O first try every time.
 		x = self.pool[index]	     -- not actually how the real thing works, but close enough.
 		self.first = false
-		didfirst = true
+		did_first = true
 	else
 		for i = 1, 6 do			 
 			index = love.math.random(#self.pool)
@@ -50,59 +50,59 @@ function History6Rolls35PoolRandomizer:generatePiece()
 			if not self:inHistory(x) then
 				break
 			end
-			didrerool=true -- checked later
-			self.pool[index]=self:GetMostDroughtedPiece()   -- update the bag
+			did_reroll=true -- checked later
+			self.pool[index]=self:getMostDroughtedPiece()   -- update the bag
 			index = love.math.random(#self.pool)		-- reroll in case we are about to fall out
 			x = self.pool[index]				-- yes, this burns an extra number from the rng most of the time.
 		end
 	end
-	highscore=self:CheckHighDroughtCount()  -- check drought count before updating histogram so we can implement the bug
-	self:UpdateHistory(x)			--  update the history even on first piece
-	self:UpdateHistogram(x)			-- update the histogram even on first piece
+	highscore=self:checkHighDroughtCount()  -- check drought count before updating histogram so we can implement the bug
+	self:updateHistory(x)			--  update the history even on first piece
+	self:updateHistogram(x)			-- update the histogram even on first piece
 	-- we only update the bag sometimes, due to a bug in TI
-	if didfirst then
+	if did_first then
 		return x -- don't update for first piece, skip the other two tests. this is not the bug, as the first piece was not drawn from the bag.
 	end
 	-- we should always update the bag here, but we only update it in two cases.
-	if highscore < self:CheckHighDroughtCount() then
-		self.pool[index]=self:GetMostDroughtedPiece()  -- do update if the high drought count went up
+	if highscore < self:checkHighDroughtCount() then
+		self.pool[index]=self:getMostDroughtedPiece()  -- do update if the high drought count went up
 	end
-	if not didreroll then
-		self.pool[index]=self:GetMostDroughtedPiece() -- do update if there was no reroll.
+	if not did_reroll then
+		self.pool[index]=self:getMostDroughtedPiece() -- do update if there was no reroll.
 	end
 	-- if neither happened, the bag does NOT get updated now. to remove the bug, comment ouut both ifs and one of the updates above, so the bag always updates except for first piece
 	return x
 end
 
-function History6Rolls35PoolRandomizer:UpdateHistory(shape)
+function History6Rolls35PoolRandomizer:updateHistory(shape)
 	table.remove(self.history, 1)
 	table.insert(self.history, shape)
 end
-function History6Rolls35PoolRandomizer:CheckHighDroughtCount()
+function History6Rolls35PoolRandomizer:checkHighDroughtCount()
 
-	local highdrought
-	local highdroughtcount = 0
+	local high_drought
+	local high_drought_count = 0
 	for k, v in pairs(self.piece_index) do
-			if self.droughts[v] >= highdroughtcount then
-				highdrought = v
-				highdroughtcount = self.droughts[v]
+			if self.droughts[v] >= high_drought_count then
+				high_drought = v
+				high_drought_count = self.droughts[v]
 			end
 	end
-	return highdroughtcount
+	return highd_rought_count
 end
-function History6Rolls35PoolRandomizer:GetMostDroughtedPiece()
+function History6Rolls35PoolRandomizer:getMostDroughtedPiece()
 
-	local highdrought 
-	local highdroughtcount = 0
+	local high_drought 
+	local high_drought_count = 0
 	for k, v in pairs(self.piece_index) do
-			if self.droughts[v] >= highdroughtcount then
-				highdrought = v
-				highdroughtcount = self.droughts[v]
+			if self.droughts[v] >= high_drought_count then
+				high_drought = v
+				high_droughtcount = self.droughts[v]
 			end
 	end
-	return highdrought
+	return high_drought
 end
-function History6Rolls35PoolRandomizer:UpdateHistogram(shape)
+function History6Rolls35PoolRandomizer:updateHistogram(shape)
 
 	for k, v in pairs(self.piece_index) do
 		if v == shape then

--- a/tetris/randomizers/history_6rolls_35bag.lua
+++ b/tetris/randomizers/history_6rolls_35bag.lua
@@ -14,14 +14,14 @@ function History6Rolls35PoolRandomizer:initialize()
 		"Z", "Z", "Z", "Z", "Z",
 		"O", "O", "O", "O", "O",
 	}
-	self.droughts = {
-		I = 0,
-		T = 0,
-		L = 0,
-		J = 0,
-		S = 0,
-		Z = 0,
-		O = 0,
+	self.droughts = {  -- don't ask me why TI does this, bit it does. :)
+		I = 4,
+		T = 4,
+		L = 4,
+		J = 4,
+		S = 4,
+		Z = 4,
+		O = 4,
 	}
 	self.piece_index = {
 		"I",
@@ -35,42 +35,83 @@ function History6Rolls35PoolRandomizer:initialize()
 end
 
 function History6Rolls35PoolRandomizer:generatePiece()
-	local index, x
+	local index, x, highscore, didreroll, didfirst
+	didreroll = false -- did we reroll
+	didfirst = false -- did we just do the first piece
 	if self.first then
-		index = love.math.random(20)
-		x = self.pool[index]
+		index = love.math.random(20) -- hack to pick non S Z O first try every time.
+		x = self.pool[index]	     -- not actually how thwe real thing works, but close enough.
 		self.first = false
+		didfirst = true
 	else
-		for i = 1, 6 do
+		for i = 1, 6 do			 
 			index = love.math.random(#self.pool)
 			x = self.pool[index]
-			if not self:inHistory(x) or i == 6 then
+			if not self:inHistory(x)
 				break
 			end
+			didrerool=true -- checked leater
+			self.pool[index]=self.GetMostDroughtedPiece()   -- update the bag
+			index = love.math.random(#self.pool)		-- reroll in case we are about to fall out
+			x = self.pool[index]				-- yes, this burns an extra number from the rng most of the time.
 		end
 	end
-	self.pool[index] = self:updateHistory(x)
+	highscore=self.CheckHighDroughtCount()  -- check drought count before updating histogram so we can implement the bug
+	self.UpdateHistory(x)			--  update the history even on first piece
+	self.UpdateHistogram(x)			-- update the histogram even on first piece
+	-- we only update the bag sometimes, due to a bug in TI
+	if didfirst then
+		return x -- don't update for first piece, skip the other two tests. this is not the bug, as the first piece was not drawn from the bag.
+	end
+	-- we should always update the bag here, but we only update it in two cases.
+	if highscore < self.CheckHighDroughtCount() then
+		self.pool[index]=self.GetMostDroughtedPiece()  -- do update if the high drought count went up
+	end
+	if not didreroll
+		self.pool[index]=self.GetMostDroughtedPiece() -- do update if there was no reroll.
+	end
+	-- if neither happened, the bag does NOT get updated now. to remove the bug, comment ouut both ifs and one of the updates above, so the bag always updates except for first piece
 	return x
 end
 
 function History6Rolls35PoolRandomizer:updateHistory(shape)
 	table.remove(self.history, 1)
 	table.insert(self.history, shape)
+end
+function History6Rolls35PoolRandomizer:CheckHighDroughtCount()
 
 	local highdrought
 	local highdroughtcount = 0
+	for k, v in pairs(self.piece_index) do
+			if self.droughts[v] >= highdroughtcount then
+				highdrought = v
+				highdroughtcount = self.droughts[v]
+			end
+	end
+	return highdroughtcount
+end
+function History6Rolls35PoolRandomizer:GetMostDroughtedPiece()
+
+	local highdrought
+	local highdroughtcount = 0
+	for k, v in pairs(self.piece_index) do
+			if self.droughts[v] >= highdroughtcount then
+				highdrought = v
+				highdroughtcount = self.droughts[v]
+			end
+	end
+	return highdrought
+end
+function History6Rolls35PoolRandomizer:UpdateHistogram(shape)
+
 	for k, v in pairs(self.piece_index) do
 		if v == shape then
 			self.droughts[v] = 0
 		else
 			self.droughts[v] = self.droughts[v] + 1
-			if self.droughts[v] >= highdroughtcount then
-				highdrought = v
-				highdroughtcount = self.droughts[v]
-			end
 		end
 	end
-	return highdrought
+	return true
 end
 
 function History6Rolls35PoolRandomizer:inHistory(piece)

--- a/tetris/randomizers/history_6rolls_35bag.lua
+++ b/tetris/randomizers/history_6rolls_35bag.lua
@@ -67,7 +67,7 @@ function History6Rolls35PoolRandomizer:generatePiece()
 	if highscore < self.CheckHighDroughtCount() then
 		self.pool[index]=self.GetMostDroughtedPiece()  -- do update if the high drought count went up
 	end
-	if not didreroll
+	if not didreroll then
 		self.pool[index]=self.GetMostDroughtedPiece() -- do update if there was no reroll.
 	end
 	-- if neither happened, the bag does NOT get updated now. to remove the bug, comment ouut both ifs and one of the updates above, so the bag always updates except for first piece

--- a/tetris/randomizers/history_6rolls_35bag.lua
+++ b/tetris/randomizers/history_6rolls_35bag.lua
@@ -111,7 +111,6 @@ function History6Rolls35PoolRandomizer:UpdateHistogram(shape)
 			self.droughts[v] = self.droughts[v] + 1
 		end
 	end
-	return true
 end
 
 function History6Rolls35PoolRandomizer:inHistory(piece)

--- a/tetris/randomizers/history_6rolls_35bag.lua
+++ b/tetris/randomizers/history_6rolls_35bag.lua
@@ -47,7 +47,7 @@ function History6Rolls35PoolRandomizer:generatePiece()
 		for i = 1, 6 do			 
 			index = love.math.random(#self.pool)
 			x = self.pool[index]
-			if not self:inHistory(x)
+			if not self:inHistory(x) then
 				break
 			end
 			didrerool=true -- checked leater

--- a/tetris/randomizers/history_6rolls_35bag.lua
+++ b/tetris/randomizers/history_6rolls_35bag.lua
@@ -14,7 +14,7 @@ function History6Rolls35PoolRandomizer:initialize()
 		"Z", "Z", "Z", "Z", "Z",
 		"O", "O", "O", "O", "O",
 	}
-	self.droughts = {  -- don't ask me why TI does this, but it does. :)
+	self.droughts = {  
 		I = 4,
 		T = 4,
 		L = 4,
@@ -40,7 +40,7 @@ function History6Rolls35PoolRandomizer:generatePiece()
 	didfirst = false -- did we just do the first piece
 	if self.first then
 		index = love.math.random(20) -- hack to pick non S Z O first try every time.
-		x = self.pool[index]	     -- not actually how thwe real thing works, but close enough.
+		x = self.pool[index]	     -- not actually how the real thing works, but close enough.
 		self.first = false
 		didfirst = true
 	else
@@ -50,31 +50,31 @@ function History6Rolls35PoolRandomizer:generatePiece()
 			if not self:inHistory(x) then
 				break
 			end
-			didrerool=true -- checked leater
-			self.pool[index]=self.GetMostDroughtedPiece()   -- update the bag
+			didrerool=true -- checked later
+			self.pool[index]=self:GetMostDroughtedPiece()   -- update the bag
 			index = love.math.random(#self.pool)		-- reroll in case we are about to fall out
 			x = self.pool[index]				-- yes, this burns an extra number from the rng most of the time.
 		end
 	end
-	highscore=self.CheckHighDroughtCount()  -- check drought count before updating histogram so we can implement the bug
-	self.UpdateHistory(x)			--  update the history even on first piece
-	self.UpdateHistogram(x)			-- update the histogram even on first piece
+	highscore=self:CheckHighDroughtCount()  -- check drought count before updating histogram so we can implement the bug
+	self:UpdateHistory(x)			--  update the history even on first piece
+	self:UpdateHistogram(x)			-- update the histogram even on first piece
 	-- we only update the bag sometimes, due to a bug in TI
 	if didfirst then
 		return x -- don't update for first piece, skip the other two tests. this is not the bug, as the first piece was not drawn from the bag.
 	end
 	-- we should always update the bag here, but we only update it in two cases.
-	if highscore < self.CheckHighDroughtCount() then
-		self.pool[index]=self.GetMostDroughtedPiece()  -- do update if the high drought count went up
+	if highscore < self:CheckHighDroughtCount() then
+		self.pool[index]=self:GetMostDroughtedPiece()  -- do update if the high drought count went up
 	end
 	if not didreroll then
-		self.pool[index]=self.GetMostDroughtedPiece() -- do update if there was no reroll.
+		self.pool[index]=self:GetMostDroughtedPiece() -- do update if there was no reroll.
 	end
 	-- if neither happened, the bag does NOT get updated now. to remove the bug, comment ouut both ifs and one of the updates above, so the bag always updates except for first piece
 	return x
 end
 
-function History6Rolls35PoolRandomizer:updateHistory(shape)
+function History6Rolls35PoolRandomizer:UpdateHistory(shape)
 	table.remove(self.history, 1)
 	table.insert(self.history, shape)
 end
@@ -92,7 +92,7 @@ function History6Rolls35PoolRandomizer:CheckHighDroughtCount()
 end
 function History6Rolls35PoolRandomizer:GetMostDroughtedPiece()
 
-	local highdrought
+	local highdrought 
 	local highdroughtcount = 0
 	for k, v in pairs(self.piece_index) do
 			if self.droughts[v] >= highdroughtcount then

--- a/tetris/randomizers/history_6rolls_35bag.lua
+++ b/tetris/randomizers/history_6rolls_35bag.lua
@@ -14,7 +14,7 @@ function History6Rolls35PoolRandomizer:initialize()
 		"Z", "Z", "Z", "Z", "Z",
 		"O", "O", "O", "O", "O",
 	}
-	self.droughts = {  -- don't ask me why TI does this, bit it does. :)
+	self.droughts = {  -- don't ask me why TI does this, but it does. :)
 		I = 4,
 		T = 4,
 		L = 4,

--- a/tetris/randomizers/history_6rolls_35bag.lua
+++ b/tetris/randomizers/history_6rolls_35bag.lua
@@ -88,7 +88,7 @@ function History6Rolls35PoolRandomizer:checkHighDroughtCount()
 				high_drought_count = self.droughts[v]
 			end
 	end
-	return highd_rought_count
+	return high_drought_count
 end
 function History6Rolls35PoolRandomizer:getMostDroughtedPiece()
 

--- a/tetris/randomizers/history_6rolls_35bag.lua
+++ b/tetris/randomizers/history_6rolls_35bag.lua
@@ -97,7 +97,7 @@ function History6Rolls35PoolRandomizer:getMostDroughtedPiece()
 	for k, v in pairs(self.piece_index) do
 			if self.droughts[v] >= high_drought_count then
 				high_drought = v
-				high_droughtcount = self.droughts[v]
+				high_drought_count = self.droughts[v]
 			end
 	end
 	return high_drought


### PR DESCRIPTION
The following changes have been made.

1) implement updating the 35 bag before each reroll.
2) implement original TI bug that causes the bag to sometimes not update when it was clearly intended.
3) implemented original fallthrough logic with rerolls. Should the PRNG ever get changed to the one that TGM games other than TGM4 use, this may actually matter. For now it doesn't.
4) added comments explaining stuff.

Not done:
1) uses actual reroll logic on first piece instead of the existing clever hack
2) change piece  ids to be same as TI's.

This has been tested, and feels much closer.