### PR TITLE
feat: added side queue position setting

### DIFF
--- a/scene/game_config.lua
+++ b/scene/game_config.lua
@@ -126,6 +126,21 @@ Side: The next piece is to the right of the board; additional previews go downwa
 		default = 1,
 	},
 	{
+		config_name = "next_side_position",
+		display_name = "Side Position",
+		options = {"Top", "Center"},
+		description = [[
+Changes the vertical position of the next queue at the side of the game board.
+Top: The top-most next piece is near the top of the board.
+Center: The top-most next piece is near the center of the board.]],
+		setter = function (a)
+            config.side_position = a == 2
+            config.gamesettings.next_side_position = a
+		end,
+		type = "options",
+		default = 1,
+	},
+	{
 		config_name = "replay_name",
 		display_name = "Replay File Name",
 		options = {"Full", "Date"},

--- a/tetris/modes/gamemode.lua
+++ b/tetris/modes/gamemode.lua
@@ -921,7 +921,11 @@ function GameMode:drawNextQueue(ruleset)
 			next_queue_position = next_queue_position + 1
 		end
 		if config.side_next then -- next at side
-			drawPiece(next_piece, skin, ruleset.block_offsets[next_piece][rotation], 192, -16+next_queue_position*48)
+            if not config.side_position then
+                drawPiece(next_piece, skin, ruleset.block_offsets[next_piece][rotation], 192, -16+next_queue_position*48)
+            else
+    			drawPiece(next_piece, skin, ruleset.block_offsets[next_piece][rotation], 192, 64+next_queue_position*48)
+            end
 		else -- next at top
 			drawPiece(next_piece, skin, ruleset.block_offsets[next_piece][rotation], -16+next_queue_position*80, -32)
 		end
@@ -966,7 +970,11 @@ function GameMode:drawScoringInfo()
 	love.graphics.setFont(font_3x5_2)
 
 	if config["side_next"] then
-		love.graphics.printf("NEXT", 240, 72, 40, "left")
+            if not config.side_position then
+        		love.graphics.printf("NEXT", 240, 72, 40, "left")
+            else
+        		love.graphics.printf("NEXT", 240, 152, 40, "left")
+            end
 	else
 		love.graphics.printf("NEXT", 64, 40, 40, "left")
 	end

--- a/tetris/modes/survival_ax.lua
+++ b/tetris/modes/survival_ax.lua
@@ -141,7 +141,6 @@ function SurvivalAXGame:drawScoringInfo()
 	)
 
 	love.graphics.setFont(font_3x5_2)
-	love.graphics.printf("NEXT", 64, 40, 40, "left")
 	if self.lines < 150 then love.graphics.printf("TIME LEFT", text_x, 250, 80, "left") end
 	love.graphics.printf("LINES", text_x, 320, 40, "left")
 

--- a/tetris/modes/survival_ax.lua
+++ b/tetris/modes/survival_ax.lua
@@ -131,6 +131,8 @@ function SurvivalAXGame:drawScoringInfo()
 
 	love.graphics.setColor(1, 1, 1, 1)
 
+	local text_x = config["side_next"] and 320 or 240
+
 	love.graphics.setFont(font_3x5)
 	love.graphics.print(
 		self.das.direction .. " " ..
@@ -140,22 +142,22 @@ function SurvivalAXGame:drawScoringInfo()
 
 	love.graphics.setFont(font_3x5_2)
 	love.graphics.printf("NEXT", 64, 40, 40, "left")
-	if self.lines < 150 then love.graphics.printf("TIME LEFT", 240, 250, 80, "left") end
-	love.graphics.printf("LINES", 240, 320, 40, "left")
+	if self.lines < 150 then love.graphics.printf("TIME LEFT", text_x, 250, 80, "left") end
+	love.graphics.printf("LINES", text_x, 320, 40, "left")
 
 	local current_section = math.floor(self.lines / 10) + 1
 	self:drawSectionTimesWithSplits(current_section)
 
 	love.graphics.setFont(font_3x5_3)
-	love.graphics.printf(self.lines, 240, 340, 40, "right")
-	love.graphics.printf(self.clear and self.lines or self:getSectionEndLines(), 240, 370, 40, "right")
+	love.graphics.printf(self.lines, text_x, 340, 40, "right")
+	love.graphics.printf(self.clear and self.lines or self:getSectionEndLines(), text_x, 370, 40, "right")
 
 	-- draw time left, flash red if necessary
 	local time_left = self.section_time_limit - math.max(self:getSectionTime(), 0)
 	if not self.game_over and not self.clear and time_left < frameTime(0,10) and time_left % 4 < 2 then
 		love.graphics.setColor(1, 0.3, 0.3, 1)
 	end
-	if self.lines < 150 then love.graphics.printf(formatTime(time_left), 240, 270, 160, "left") end
+	if self.lines < 150 then love.graphics.printf(formatTime(time_left), text_x, 270, 160, "left") end
 	love.graphics.setColor(1, 1, 1, 1)
 end
 


### PR DESCRIPTION
The next piece queue on the side when positioned near the top is hard to see when the eyes need to stay focused on the grid at high gravity.

Perhaps the setting could be expanded to center the queue vertically on the side depending on how many pieces are visible in the queue in a given game mode.