### PR TITLE
Added actually accurate TAP and TI randomizers

### DIFF
--- a/tetris/randomizers/TAP_Randomizer.lua
+++ b/tetris/randomizers/TAP_Randomizer.lua
@@ -1,0 +1,75 @@
+local Randomizer = require 'tetris.randomizers.randomizer'
+
+local TAPRandomizer = Randomizer:extend()
+local seed
+
+-- TAP's LCG 
+
+local function lcg()
+    seed = (129749 * seed)%(2^32) -- can overflow max safe integer range if we don't break this up and apply overflow here.
+    seed = (seed * 8505 +12345) % (2^32)    -- second overflow check, just in case.
+    return math.floor(seed / (2 ^ 10)) % 32768     -- mulitple of 3 bits used minimizes modulo bias to lowest possible. 0 and 32767 are both I.
+end
+
+local function lcgRandom(n)           -- usable for any number of pieces
+    return lcg() % n + 1              -- adds one to convert from normal LCG to LOVE
+end
+
+function TAPRandomizer:initialize()
+	self.history = {"Z", "S", "S", "Z"}
+	self.first = true
+	seed = love.math.random(0, 0xFFFFFFFF)
+end
+
+function TAPRandomizer:generatePiece()
+	local shapes = {"I", "Z", "S", "J", "L", "O", "T"} -- corrected to actual order for TAP.
+	local index, x
+	if self.first then
+		while self.first do
+			index=lcgRandom(7)
+			x = shapes[index]  -- get piece.
+		        if x == "I" then          -- if an I
+		            self.first = false    -- accept
+		        end
+		        if x == "L" then          -- if an L
+		            self.first = false    -- accept
+		        end
+		        if x == "J" then          -- if an J
+		            self.first = false    -- accept
+		        end
+		        if x == "T" then          -- if an T
+		            self.first = false    -- accept
+		        end
+			-- otherwise loop around again.
+		end
+		return self:updateHistory(x) -- found first piece not SZO
+	else
+		-- original program bug.  local x = lcgRandom(7) should be on this line instead.
+		for i = 1, 5 do  
+			index = lcgRandom(7)  -- this line should be empty
+			if not self:inHistory(shapes[index]) then
+	                	break         -- leave loop if we found apiece
+        		end
+			index = lcgRandom(7)  -- if we didn't, roll again in case we fall out.
+		end
+		return self:updateHistory(shapes[index]) -- either we fell out or not, return piece and update history.
+
+	end
+end
+
+function TAPRandomizer:updateHistory(shape)
+	table.remove(self.history, 1)
+	table.insert(self.history, shape)
+	return shape
+end
+
+function TAPRandomizer:inHistory(piece)
+	for idx, entry in pairs(self.history) do
+		if entry == piece then
+			return true
+		end
+	end
+	return false
+end
+
+return TAPRandomizer

--- a/tetris/randomizers/TAP_Randomizer.lua
+++ b/tetris/randomizers/TAP_Randomizer.lua
@@ -3,12 +3,12 @@ local Randomizer = require 'tetris.randomizers.randomizer'
 local TAPRandomizer = Randomizer:extend()
 local seed
 
--- TAP's LCG 
+-- TGM's LCG. used for every TGM game's history based randomizer.
 
 local function lcg()
     seed = (129749 * seed)%(2^32) -- can overflow max safe integer range if we don't break this up and apply overflow here.
     seed = (seed * 8505 +12345) % (2^32)    -- second overflow check, just in case.
-    return math.floor(seed / (2 ^ 10)) % 32768     -- mulitple of 3 bits used minimizes modulo bias to lowest possible. 0 and 32767 are both I.
+    return math.floor(seed / (2 ^ 10)) % 32768     -- mulitple of 3 bits used minimizes modulo bias for 7 to lowest possible. 0 and 32767 are both I.
 end
 
 local function lcgRandom(n)           -- usable for any number of pieces
@@ -18,7 +18,7 @@ end
 function TAPRandomizer:initialize()
 	self.history = {"Z", "S", "S", "Z"}
 	self.first = true
-	seed = love.math.random(0, 0xFFFFFFFF)
+	seed = love.math.random(0, 0xFFFFFFFF) -- use LOVE to set initial seed so replays will sync. 
 end
 
 function TAPRandomizer:generatePiece()

--- a/tetris/randomizers/TI_Randomizer.lua
+++ b/tetris/randomizers/TI_Randomizer.lua
@@ -1,0 +1,159 @@
+-- This is the Ti randomizer.
+-- Now contains the TGM LGC, and chooses the actual first piece with infinite rerolls like the real game does.
+
+local Randomizer = require 'tetris.randomizers.randomizer'
+
+local TIRandomizer = Randomizer:extend()
+
+local seed
+
+-- ANSI C LCG (TGM variant)
+
+local function lcg()
+    seed = (129749 * seed)%(2^32) -- can overflow max safe integer range if we don't break this up and apply overflow here.
+    seed = (seed * 8505 +12345) % (2^32)    -- second overflow check, just in case.
+    return math.floor(seed / (2 ^ 10)) % 32768     -- slight I bias, cuz 32767 is an I.
+end
+
+local function lcgRandom(n)
+    return lcg() % n + 1
+end
+
+function TIRandomizer:initialize()
+    self.first = true
+    self.history = { "Z", "S", "S", "Z" }
+    self.pool = {
+        "I", "I", "I", "I", "I",
+        "Z", "Z", "Z", "Z", "Z",
+        "S", "S", "S", "S", "S",
+        "J", "J", "J", "J", "J",
+        "L", "L", "L", "L", "L",
+        "O", "O", "O", "O", "O",
+        "T", "T", "T", "T", "T",  -- correct bag order
+    }
+    self.droughts = {
+        I = 4,
+        Z = 4,
+        S = 4,
+        J = 4,
+        L = 4,
+        O = 4,
+        T = 4,
+    }
+    self.piece_index = {
+        "I",
+        "Z",
+        "S",
+        "J",
+        "L",
+        "O",
+        "T",
+    }
+    seed = love.math.random(0, 0xFFFFFFFF) -- pick random 32 bit unsigned starting seed in replay compatible fashion. 
+end
+
+function TIRandomizer:generatePiece()
+    local index, x, highscore, didreroll, didfirst
+    didreroll = false         -- did we reroll
+    didfirst = false          -- did we just do the first piece
+    if self.first then
+	while self.first do
+            index = lcgRandom(35) -- hack removed
+            x = self.pool[index]  -- get piece.
+            if x == "I" then          -- if an I
+                self.first = false    -- accept
+            end
+            if x == "L" then          -- if an L
+                self.first = false    -- accept
+            end
+            if x == "J" then          -- if an J
+                self.first = false    -- accept
+            end
+            if x == "T" then          -- if an T
+                self.first = false    -- accept
+            end
+            didfirst = true           -- regardless once done rerolling, didfirst is true, safe to set it here.
+        end
+    else
+        for i = 1, 5 do
+            index = lcgRandom(#self.pool)
+            x = self.pool[index]
+            if not self:inHistory(x) then
+                break
+            end
+            didreroll = true                                -- checked later
+            self.pool[index] = self:GetMostDroughtedPiece() -- update the bag
+            index = lcgRandom(#self.pool)                   -- reroll in case we are about to fall out
+            x = self.pool
+                [index]                                     -- yes, this burns an turbo number from the rng most of the time.
+        end
+    end
+    highscore = self:CheckHighDroughtCount() -- check drought count before updating histogram so we can implement the bug
+    self:UpdateHistory(x)                    --  update the history even on first piece
+    self:UpdateHistogram(x)                  -- update the histogram even on first piece
+    -- we only update the bag sometimes, due to a bug in TI
+    if didfirst then
+        return x  -- first piece never updates the bag. not part of the bug.
+    end
+
+    -- we should always update the bag here, but we only update it in two cases.
+    if highscore < self:CheckHighDroughtCount() then
+        self.pool[index] = self:GetMostDroughtedPiece() -- do update if the high drought count went up
+    end
+    if not didreroll then
+        self.pool[index] = self:GetMostDroughtedPiece() -- do update if there was no reroll.
+    end
+    -- if neither happened, the bag does NOT get updated now. 
+    -- to remove the bug, comment ouut both ifs and one of the updates above, so the bag always updates except for first piece
+    return x
+end
+
+function TIRandomizer:UpdateHistory(shape)
+    table.remove(self.history, 1)
+    table.insert(self.history, shape)
+end
+
+function TIRandomizer:CheckHighDroughtCount()
+    local highdrought
+    local highdroughtcount = 0
+    for k, v in pairs(self.piece_index) do
+        if self.droughts[v] >= highdroughtcount then
+            highdrought = v
+            highdroughtcount = self.droughts[v]
+        end
+    end
+    return highdroughtcount
+end
+
+function TIRandomizer:GetMostDroughtedPiece()
+    local highdrought
+    local highdroughtcount = 0
+    for k, v in pairs(self.piece_index) do
+        if self.droughts[v] >= highdroughtcount then
+            highdrought = v
+            highdroughtcount = self.droughts[v]
+        end
+    end
+    return highdrought
+end
+
+function TIRandomizer:UpdateHistogram(shape)
+    for k, v in pairs(self.piece_index) do
+        if v == shape then
+            self.droughts[v] = 0
+        else
+            self.droughts[v] = self.droughts[v] + 1
+        end
+    end
+end
+
+function TIRandomizer:inHistory(piece)
+    for idx, entry in pairs(self.history) do
+        if entry == piece then
+            return true
+        end
+    end
+    return false
+end
+
+return TIRandomizer

--- a/tetris/randomizers/TI_Randomizer.lua
+++ b/tetris/randomizers/TI_Randomizer.lua
@@ -7,12 +7,12 @@ local TIRandomizer = Randomizer:extend()
 
 local seed
 
--- ANSI C LCG (TGM variant)
+-- TGM's LCG.  used by every history based randomizer in every TGM game.
 
 local function lcg()
     seed = (129749 * seed)%(2^32) -- can overflow max safe integer range if we don't break this up and apply overflow here.
     seed = (seed * 8505 +12345) % (2^32)    -- second overflow check, just in case.
-    return math.floor(seed / (2 ^ 10)) % 32768     -- slight I bias, cuz 32767 is an I.
+    return math.floor(seed / (2 ^ 10)) % 32768     -- slight I bias for modulo 7, cuz 32767 is an I.
 end
 
 local function lcgRandom(n)
@@ -29,7 +29,7 @@ function TIRandomizer:initialize()
         "J", "J", "J", "J", "J",
         "L", "L", "L", "L", "L",
         "O", "O", "O", "O", "O",
-        "T", "T", "T", "T", "T",  -- correct bag order
+        "T", "T", "T", "T", "T",  -- thtis is the correct intial seed.
     }
     self.droughts = {
         I = 4,
@@ -38,7 +38,7 @@ function TIRandomizer:initialize()
         J = 4,
         L = 4,
         O = 4,
-        T = 4,
+        T = 4, -- starting drought counters.
     }
     self.piece_index = {
         "I",
@@ -49,7 +49,7 @@ function TIRandomizer:initialize()
         "O",
         "T",
     }
-    seed = love.math.random(0, 0xFFFFFFFF) -- pick random 32 bit unsigned starting seed in replay compatible fashion. 
+    seed = love.math.random(0, 0xFFFFFFFF) -- pick random 32 bit unsigned starting seed in replay compatible fashion.  not sure if all of these are usable by TI
 end
 
 function TIRandomizer:generatePiece()
@@ -58,7 +58,7 @@ function TIRandomizer:generatePiece()
     didfirst = false          -- did we just do the first piece
     if self.first then
 	while self.first do
-            index = lcgRandom(35) -- hack removed
+            index = lcgRandom(35) -- hack removed.  infinite rerolls to pick first piece
             x = self.pool[index]  -- get piece.
             if x == "I" then          -- if an I
                 self.first = false    -- accept
@@ -75,17 +75,16 @@ function TIRandomizer:generatePiece()
             didfirst = true           -- regardless once done rerolling, didfirst is true, safe to set it here.
         end
     else
-        for i = 1, 5 do
-            index = lcgRandom(#self.pool)
-            x = self.pool[index]
+        for i = 1, 5 do					   -- no, this is not an error in my implementation. the cocde does 1, 3, 5 7 9, or 10 rolls.  these correspond to 1 2 3 4 5 6
+            index = lcgRandom(#self.pool)  -- this pair of lines was probably ment to be above the loop
+            x = self.pool[index]           -- if it were, no rolls would be wasted, but their sequences wouldn't match the real game.
             if not self:inHistory(x) then
                 break
             end
             didreroll = true                                -- checked later
-            self.pool[index] = self:GetMostDroughtedPiece() -- update the bag
+            self.pool[index] = self:GetMostDroughtedPiece() -- update the bag. yes if you have to reroll a piece the peice you jsut rolled is now less likely to repeat.
             index = lcgRandom(#self.pool)                   -- reroll in case we are about to fall out
-            x = self.pool
-                [index]                                     -- yes, this burns an turbo number from the rng most of the time.
+            x = self.pool[index]                            -- yes, this burns an extra number from the rng most of the time.
         end
     end
     highscore = self:CheckHighDroughtCount() -- check drought count before updating histogram so we can implement the bug


### PR DESCRIPTION
These two randomizers written by me are the actual ones REed from the games, translated to LUA.

All quirks of the original randomizers are retained, and given any given seed, the same sequence should generate as the actual arcade.

Swapping these into existing TGM modes will break old replays, so this commit does not do that, instead providing these two randomizers as new ones.

I hope this is accepted.